### PR TITLE
Allow passing required scopes to calculated attributes

### DIFF
--- a/lib/calculated_attributes/model_methods.rb
+++ b/lib/calculated_attributes/model_methods.rb
@@ -13,14 +13,12 @@ module CalculatedAttributes
 
   class CalculatedAttributes
     class Callable
-      def initialize(lambda, options={})
+      def initialize(lambda, options = {})
         @lambda = lambda
         @options = options
       end
 
-      def options
-        @options
-      end
+      attr_reader :options
 
       def call(*args)
         @lambda.call(*args)
@@ -117,9 +115,9 @@ module ActiveRecord
         projections.push new_projection
         callables.push(callable)
       end
-      callables.inject(self) do |s, callable|
-        (callable.options[:requires_scopes] || []).inject(s) do |_s, scope|
-          _s.send(scope)
+      callables.inject(self) do |self1, callable|
+        (callable.options[:requires_scopes] || []).inject(self1) do |self2, scope|
+          self2.send(scope)
         end
       end.select(projections)
     end

--- a/lib/calculated_attributes/model_methods.rb
+++ b/lib/calculated_attributes/model_methods.rb
@@ -1,15 +1,38 @@
 module CalculatedAttributes
-  def calculated(*args)
+  def calculated(*args, &block)
     @config ||= CalculatedAttributes::Config.new
-    @config.calculated(args.first, args.last) if args.size == 2
+    if block
+      @config.calculated(args.first, options: args[1], &block)
+    elsif args.size == 2
+      @config.calculated(args.first, args.last)
+    elsif args.size == 3
+      @config.calculated(args.first, args.last, options: args[1])
+    end
     @config
   end
 
   class CalculatedAttributes
+    class Callable
+      def initialize(lambda, options={})
+        @lambda = lambda
+        @options = options
+      end
+
+      def options
+        @options
+      end
+
+      def call(*args)
+        @lambda.call(*args)
+      end
+    end
+
     class Config
-      def calculated(title = nil, lambda = nil)
+      def calculated(title = nil, lambda = nil, options: {}, &block)
+        lambda = block if block_given? && !lambda
+
         @calculations ||= {}
-        @calculations[title] ||= lambda if title && lambda
+        @calculations[title] ||= Callable.new(lambda, options) if title && lambda
         @calculations
       end
     end
@@ -77,9 +100,10 @@ module ActiveRecord
         end
       end
 
+      callables = []
       args.each do |attribute, arguments|
-        lam = klass.calculated.calculated[attribute] || klass.base_class.calculated.calculated[attribute]
-        sql = lam.call(*arguments)
+        callable = klass.calculated.calculated[attribute] || klass.base_class.calculated.calculated[attribute]
+        sql = callable.call(*arguments)
         sql = klass.send(:sanitize_sql, *sql) if sql.is_a?(Array)
         new_projection =
           if sql.is_a?(String)
@@ -91,8 +115,13 @@ module ActiveRecord
           end
         new_projection.calculated_attr!
         projections.push new_projection
+        callables.push(callable)
       end
-      select(projections)
+      callables.inject(self) do |s, callable|
+        (callable.options[:requires_scopes] || []).inject(s) do |_s, scope|
+          _s.send(scope)
+        end
+      end.select(projections)
     end
   end
 end

--- a/spec/lib/calculated_attributes_spec.rb
+++ b/spec/lib/calculated_attributes_spec.rb
@@ -32,6 +32,11 @@ describe 'calculated_attributes' do
     expect(post.comments_two).to eq(1)
   end
 
+  it 'allows specifying required scopes for calculation' do
+    post = model_scoped(Post).calculated(:recent_comment_count).first
+    expect(post.recent_comment_count).to eq(1)
+  end
+
   it 'nests with where query' do
     expect(Post.where(id: 1).calculated(:comments_count).first.comments_count).to eq(1)
   end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -7,6 +7,14 @@ class Post < ActiveRecord::Base
   calculated :comments_two, -> { 'select count(*) from comments where comments.post_id = posts.id' }
   calculated :comments_arel, -> { Comment.where(Comment.arel_table[:post_id].eq(Post.arel_table[:id])).select(Arel.sql('count(*)')) }
   calculated :comments_to_sql, -> { Comment.where('comments.post_id = posts.id').select('count(*)') }
+
+  scope :recent, -> {
+    where(created_at: (Time.now - 1.day)..Time.now)
+  }
+
+  calculated :recent_comment_count, requires_scopes: [:recent] do
+    'select count(*) from comments where comments.post_id = posts.id'
+  end
 end
 
 class Tutorial < Post

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -8,7 +8,7 @@ class Post < ActiveRecord::Base
   calculated :comments_arel, -> { Comment.where(Comment.arel_table[:post_id].eq(Post.arel_table[:id])).select(Arel.sql('count(*)')) }
   calculated :comments_to_sql, -> { Comment.where('comments.post_id = posts.id').select('count(*)') }
 
-  scope :recent, -> {
+  scope :recent, lambda {
     where(created_at: (Time.now - 1.day)..Time.now)
   }
 


### PR DESCRIPTION
This allows automatically including additional scopes when calling the calculated method.