### PR TITLE
Support .count on relations that have previously had  applied

### DIFF
--- a/lib/calculated_attributes/model_methods.rb
+++ b/lib/calculated_attributes/model_methods.rb
@@ -121,5 +121,12 @@ module ActiveRecord
         end
       end.select(projections)
     end
+
+    private
+
+    def calculate(operation, column_name)
+      self.select_values = [] if select_values.any? { |p| p.is_a?(Arel::Nodes::Node) && p.calculated_attr? }
+      super
+    end
   end
 end

--- a/spec/lib/calculated_attributes_spec.rb
+++ b/spec/lib/calculated_attributes_spec.rb
@@ -109,6 +109,24 @@ describe 'calculated_attributes' do
     expect(model_scoped(Article).calculated(:sub_comments).first.sub_comments).to eq(1)
   end
 
+  context 'when using aggregate calculations' do
+    it 'supports count on a relation with calculated attributes' do
+      expect(model_scoped(Post).calculated(:comments_count).count).to eq(Post.count)
+    end
+
+    it 'supports count on a relation with multiple calculated attributes' do
+      expect(model_scoped(Post).calculated(:comments_count, :comments_two).count).to eq(Post.count)
+    end
+
+    it 'supports sum on a relation with calculated attributes' do
+      expect(model_scoped(Post).calculated(:comments_count).sum(:id)).to eq(Post.sum(:id))
+    end
+
+    it 'supports count with where clause and calculated attributes' do
+      expect(Post.where(text: 'First post!').calculated(:comments_count).count).to eq(1)
+    end
+  end
+
   context 'when joining models' do
     it 'includes calculated attributes' do
       expect(model_scoped(Post).joins(:comments).calculated(:comments_count).first.comments_count).to eq(1)


### PR DESCRIPTION
The bug was that .calculated(:start_date, :end_date) adds Arel::Nodes::As projections to select_values, and when AR's calculate builds the aggregate query it passes those selects into COUNT(col1, col2, ... AS start_date, ... AS end_date) — invalid SQL in both PostgreSQL and SQLite.